### PR TITLE
upgrade OMI image, RKE & Kube versions

### DIFF
--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -3,7 +3,7 @@
 #region              = "eu-west-2"
 
 # Ubuntu Image, check latest on https://docs.outscale.com/en/userguide/Official-OMIs-Reference.html
-image_id                  = "ami-9b41b457" # Ubuntu-22.04-2023.02.21-0 (created: 2023-02-21) on us-east-2
+image_id                  = "ami-a3ca408c" # Ubuntu-22.04-2023.12.04-0
 control_plane_vm_type     = "tinav6.c4r8p1"
 control_plane_count       = 1
 control_plane_volume_type = "io1"
@@ -19,7 +19,7 @@ bastion_volume_type       = "io1"
 bastion_volume_size       = 15
 bastion_iops              = 1500
 cluster_name              = "phandalin"
-rke_version               = "v1.4.4"
-kubernetes_version        = "v1.25.6-rancher4-1" # See available version https://github.com/rancher/rke/releases
+rke_version               = "v1.5.10"
+kubernetes_version        = "v1.28.10-rancher1-1" # See available version https://github.com/rancher/rke/releases
 will_install_ccm          = false                # Set to true if the CCM of osc will be installed
 public_cloud              = false


### PR DESCRIPTION
I got errors with the current versions, so upgraded to recent ones.

The OMI is missing, I upgraded to a more recent version of ubuntu taking care of using an official Outscale image.

Also upgraded RKE & Kube version.
